### PR TITLE
Fix rf_impute bug where nrow(test) != nrow(train)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+scikit-learn
+statsmodels

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -73,5 +73,5 @@ def rf_impute(x_train, y_train, x_new, x_cols=None, random_state=None,
         rf.fit(x_train, y_train, sample_weight=sample_weight_train)
     if random_state is not None:
         np.random.seed(random_state)
-    quantiles = np.random.rand(y_train.size)  # Uniform distribution.
+    quantiles = np.random.rand(x_new.shape[0])  # Uniform distribution.
     return rf_quantile(rf, x_new, quantiles)

--- a/synthimpute/tests/test_rf_impute.py
+++ b/synthimpute/tests/test_rf_impute.py
@@ -5,7 +5,7 @@ from sklearn import ensemble
 
 
 def test_rf_impute():
-    N_TRAIN = 1000
+    N_TRAIN = 2000
     N_NEW = 1000
     n = N_TRAIN + N_NEW
     x = pd.DataFrame({'x1': np.random.randn(n),


### PR DESCRIPTION
Fixes #32. Also changes the test to check for this case.